### PR TITLE
Add logic to free memory when deleting nodes, finish edge cases (adding multiple copies of same value, deleting root node)

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -40,7 +40,7 @@ Insertion:
 
 Deletion:
 - BIG IDEA: check color of sibling
-- Bottom up method:
+- 1) Bottom up method:
   - https://www.cs.purdue.edu/homes/ayg/CS251/slides/chap13c.pdf
   - https://ebooks.inflibnet.ac.in/csp01/chapter/red-black-trees-ii/
   - if node has no children that are leaf nodes
@@ -62,7 +62,7 @@ Deletion:
     - Case 3: if sibling is red
           - adjustment
           - rotate around parent to bring sibling up
-- Another way of looking at the bottom up method (pure actions, no theory)
+- 2) Another way of looking at the bottom up method (pure actions, no theory)
   - https://www.youtube.com/watch?v=eoQpRtMpA9I
   - 3 nodes to consider: node being deleted, the replacement, x (differs depending on condition)
   - not really recursive, so many cases 0.0 
@@ -104,88 +104,85 @@ Deletion:
     - Case 4: x is black, w is black
       - a. x is left child, w's right child is red
       - b. x is right child, w's left child is red
+      - etc. (refer to youtube video)
 
-  Method we choose:
+  Combining 1) and 2) -> http://mainline.brynmawr.edu/Courses/cs246/spring2016/lectures/16_RedBlackTrees.pdf:
 
-// DELETE Step 1: Do normal BST deletion
-// - may have to find successor and replace the node's value with the successor's value
-// - then delete the successor node
-// Note: Either we end up deleting the node itself (leaf), or we end up deleting the successor (leaf or only one child)
+  Step 1: Do normal BST deletion
+  - may have to find successor and replace the node's value with the successor's value
+  - then delete the successor node
+  Note: Either we end up deleting the node itself (leaf), or we end up deleting the successor (leaf or only one child)
 
-// DELETE Step 2: Recolor
-// - look at the node to be deleted (this would be the successor if it applies)
-// - Let u be the node to be deleted (either the original node or the successor node) and v be the child that replaces u.
-// - if u has no children, v is NIL and black
-// - if u has one one child, v, the replacement, is u's child
-// - u CANNOT have 2 children, otherwise we have not found the successor properly
-// - u AND v cannot be red as then this would not have been a valid rb tree
-// - 2a: if u is red and v is black, simply replace u with v - DONE
-//    Before:      After:
-//     U (R)        V(B)
-//      \
-//       V (B)
-// - 2b: if u is black and v is red, then when v replaces u, mark v as black - DONE
-//    Before:      After:         After2:
-//     U(B)         V(R)           V(B!)
-//      \
-//       V(R)
-// - 2c: if u is black and v is black - we get a DOUBLE BLACK - proceed to step 3
+  Step 2: Recolor
+  - look at the node to be deleted (this would be the successor if it applies)
+  - Let u be the node to be deleted (either the original node or the successor node) and v be the child that replaces u.
+  - if u has no children, v is NIL and black
+  - if u has one one child, v, the replacement, is u's child
+  - u CANNOT have 2 children, otherwise we have not found the successor properly
+  - u AND v cannot be red as then this would not have been a valid rb tree
+  - 2a: if u is red and v is black, simply replace u with v - DONE
+     Before:      After:
+      U (R)        V(B)
+       \
+        V (B)
+  - 2b: if u is black and v is red, then when v replaces u, mark v as black - DONE
+     Before:      After:         After2:
+      U(B)         V(R)           V(B!)
+       \
+        V(R)
+  - 2c: if u is black and v is black - we get a DOUBLE BLACK - proceed to step 3
+    - NOTE that if v is NIL, v can also still be DOUBLE BLACK - this has to be handled as well!!
 
-// Step 3: Dealing with DOUBLE BLACKS - when both U and V are black
-// - V becomes DOUBLE BLACK when it replaces U
-// - let P = the parent of V
-// - let S = the sibling of V
+  Step 3: Dealing with DOUBLE BLACKS - when both U and V are black
+  - V becomes DOUBLE BLACK when it replaces U
+  - let P = the parent of V
+  - let S = the sibling of V
 
-// - 3a: V's sibling, S, is red -> rotate P to bring up S, recolor S and P.
-// Continue to cases 3b, 3c, 3d
-//
-//    Before:               After:            After2:
-//        P(B)               S(R)              S(B!)
-//      /     \             /   \             /   \
-//     V(DB)  S(R)        P(B)  SR          P(R!)  SR
-//           /   \       /    \            /    \
-//          SL   SR     V(DB)  SL        V(DB)   SL
+  - 3a: V's sibling, S, is red -> rotate P to bring up S, recolor S and P.
+    Continue to cases 3b, 3c, 3d
+     Before:               After:            After2:
+         P(B)               S(R)              S(B!)
+       /     \             /   \             /   \
+      V(DB)  S(R)        P(B)  SR          P(R!)  SR
+            /   \       /    \            /    \
+           SL   SR     V(DB)  SL        V(DB)   SL
 
 
-// - 3b: V's sibling, S, is black and has two black children
-//    - recolor S red
-//    - if P is red -> make P black (absorbs V's blackness) -> DONE
-//    - if P is black -> now P is double black - reiterate up the tree (Call cases 3a-d on P)
-//    - or in the case of pointer reinforcement, simply return the parent node as a double black
-//
-//    Before:              If P was Red:          If P was Black:
-//        P(B)                P(B!)                    P(DB!)
-//      /     \              /     \                   /   \
-//     V(DB)  S(B)         V(B!)  S(R!)             V(B!)  S(R!)
-//           /   \                /   \                    /   \
-//        SL(B)   SR(B)        SL(B) SR(B)              SL(B) SR(B)
+  - 3b: V's sibling, S, is black and has two black children
+     - recolor S red
+     - if P is red -> make P black (absorbs V's blackness) -> DONE
+     - if P is black -> now P is double black - reiterate up the tree (Call cases 3a-d on P)
+     - or in the case of pointer reinforcement, simply return the parent node as a double black
+     Before:              If P was Red:          If P was Black:
+         P(B)                P(B!)                    P(DB!)
+       /     \              /     \                   /   \
+      V(DB)  S(B)         V(B!)  S(R!)             V(B!)  S(R!)
+            /   \                /   \                    /   \
+         SL(B)   SR(B)        SL(B) SR(B)              SL(B) SR(B)
 
-// - 3c: S is black, S's child further away from V is RED, other child (closer to V) is any color
-//    - rotate P to bring S up
-//    - swap colors of S and P, make S's RED child BLACK -> DONE
-//
-//       Before:                 After:            After2:
-//        P(X)                   S(B)              S(X!)
-//       /    \                 /   \             /   \
-//     V(DB)  S(B)            P(X)   SR(R)      P(B!)  SR(B!)
-//           /   \           /    \            /    \
-//          SL   SR(R)    V(DB)    SL        V(B!)    SL
+  - 3c: S is black, S's child further away from V is RED, other child (closer to V) is any color
+     - rotate P to bring S up
+     - swap colors of S and P, make S's RED child BLACK -> DONE
+        Before:                 After:            After2:
+         P(X)                   S(B)              S(X!)
+        /    \                 /   \             /   \
+      V(DB)  S(B)            P(X)   SR(R)      P(B!)  SR(B!)
+            /   \           /    \            /    \
+           SL   SR(R)    V(DB)    SL        V(B!)    SL
 
-// - 3d: S is black, S's child further away from V is BLACK, other child (closer to V) is RED
-//    - rotate S to bring up S's RED child
-//    - swap color of S and S's original RED child
-//    - proceed to case 3c
-//
-//
+  - 3d: S is black, S's child further away from V is BLACK, other child (closer to V) is RED
+     - rotate S to bring up S's RED child
+     - swap color of S and S's original RED child
+     - proceed to case 3c
 
   - So how can you do pointer reinforcement with this method??
-  -  If have to replace data with data in successor - swap data, but keep recursing until you reach the value to delete (will be in successor) then call DELETE
-  -  DELETE_FIX_UP should be called on the parent -> this allows us to return the same link for cases 3b, 3c, 3d
+  - If have to replace data with data in successor - swap data, but keep recursing until you reach the value to delete (will be in successor) then call DELETE
+  - DELETE_FIX_UP should be called on the parent -> this allows us to return the same link for cases 3b, 3c, 3d
     - (eg. parent checks if child is double black)
     - But Case 3a causes problems -> we move the problem DOWN THE TREE instead of UP THE TREE, which means we can't get out of recursive call just yet
       - we have to recurse down the tree again, calling delete_fix_up on P again
       
-      pseudocode:
+      Pseudocode:
 
       fn delete(node) -> node {
         if node.value == value {

--- a/src/queue.zig
+++ b/src/queue.zig
@@ -45,7 +45,9 @@ pub fn Queue(comptime T: type) type {
                 if (self.head == null) {
                     self.tail = null;
                 }
-                return head.data;
+                const data = head.data;
+                self.allocator.destroy(head);
+                return data;
             } else {
                 return null;
             }

--- a/src/queue.zig
+++ b/src/queue.zig
@@ -40,13 +40,14 @@ pub fn Queue(comptime T: type) type {
 
         pub fn pop(self: *Self) ?T {
             if (self.head) |head| {
+                const data = head.data;
                 self.head = head.next;
+                self.allocator.destroy(head);
                 // last item popped
                 if (self.head == null) {
                     self.tail = null;
                 }
-                const data = head.data;
-                self.allocator.destroy(head);
+
                 return data;
             } else {
                 return null;

--- a/src/rbtree.zig
+++ b/src/rbtree.zig
@@ -36,7 +36,7 @@ pub fn RedBlackTree(comptime T: type) type {
             return .{ .black_height = 0, .root = null, .allocator = allocator };
         }
 
-        pub fn flip_dir(dir: Direction) Direction {
+        fn flip_dir(dir: Direction) Direction {
             if (dir == Direction.left) {
                 return Direction.right;
             }
@@ -90,6 +90,24 @@ pub fn RedBlackTree(comptime T: type) type {
             const node = try self.allocator.create(Node);
             node.* = .{ .data = data, .children = [_]?*Node{ null, null }, .color = Color.red, .frequency = 1, .height = 0 };
             return node;
+        }
+
+        pub fn get_data(self: *Self, data: T) ?*Node {
+            return do_get_data(self, data, self.root);
+        }
+
+        fn do_get_data(self: *Self, data: T, node: ?*Node) ?*Node {
+            if (node) |n| {
+                if (n.data == data) {
+                    return n;
+                } else if (n.data > data) {
+                    return do_get_data(self, data, n.children[@intFromEnum(Direction.right)]);
+                } else {
+                    return do_get_data(self, data, n.children[@intFromEnum(Direction.left)]);
+                }
+            } else {
+                return null;
+            }
         }
 
         pub fn insert(self: *Self, data: T) !void {
@@ -320,7 +338,7 @@ pub fn RedBlackTree(comptime T: type) type {
 
         /// Double black case
         /// http://mainline.brynmawr.edu/Courses/cs246/spring2016/lectures/16_RedBlackTrees.pdf
-        pub fn do_delete(self: *Self, data: T, node: ?*Node) !?*Node {
+        fn do_delete(self: *Self, data: T, node: ?*Node) !?*Node {
             if (node) |n| {
                 print_node(n);
                 // DELETE Step 1: Do normal BST deletion
@@ -329,52 +347,57 @@ pub fn RedBlackTree(comptime T: type) type {
                 // Note: Either we end up deleting the node itself (leaf), or we end up deleting the successor (leaf or only one child)
 
                 if (n.data == data) {
-                    if (n.children[@intFromEnum(Direction.left)]) |left| {
-                        if (n.children[@intFromEnum(Direction.right)] != null) {
-                            // 2 children
-                            var predecessor = get_predecessor_when_left_subtree_exists(self, n);
-                            std.debug.print("{s} ", .{"\nFound predecessor:"});
-                            if (predecessor) |sc| {
-                                print_node(sc);
+                    if (n.frequency == 1) {
+                        if (n.children[@intFromEnum(Direction.left)]) |left| {
+                            if (n.children[@intFromEnum(Direction.right)] != null) {
+                                // 2 children
+                                var predecessor = get_predecessor_when_left_subtree_exists(self, n);
+                                std.debug.print("{s} ", .{"\nFound predecessor:"});
+                                if (predecessor) |sc| {
+                                    print_node(sc);
+                                } else {
+                                    std.debug.print("{s} ", .{"\nFailed to find predecessor:"});
+                                }
+                                const temp = n.data;
+                                n.data = predecessor.?.data; // put node data inside successor, keep going down the tree
+                                predecessor.?.data = temp;
+                                n.children[@intFromEnum(Direction.left)] = try do_delete(self, data, left);
+                                var res = try fix_double_black(self, n, Direction.left);
+                                if (!res.modified) {
+                                    res = try fix_double_black(self, n, Direction.right);
+                                }
+                                res.node.height = height(res.node.children[@intFromEnum(Direction.left)], res.node.children[@intFromEnum(Direction.right)]);
+                                print_node(res.node);
+                                return res.node;
                             } else {
-                                std.debug.print("{s} ", .{"\nFailed to find predecessor:"});
+                                // u has one left child - the replacement, v, is u's left child
+                                delete_recolor(n, left);
+                                self.allocator.destroy(n); // free memory used by u, return v
+                                return left;
                             }
-                            const temp = n.data;
-                            n.data = predecessor.?.data; // put node data inside successor, keep going down the tree
-                            predecessor.?.data = temp;
-                            n.children[@intFromEnum(Direction.left)] = try do_delete(self, data, left);
-                            var res = try fix_double_black(self, n, Direction.left);
-                            if (!res.modified) {
-                                res = try fix_double_black(self, n, Direction.right);
-                            }
-                            res.node.height = height(res.node.children[@intFromEnum(Direction.left)], res.node.children[@intFromEnum(Direction.right)]);
-                            print_node(res.node);
-                            return res.node;
-                        } else {
-                            // u has one left child - the replacement, v, is u's left child
-                            delete_recolor(n, left);
+                        } else if (n.children[@intFromEnum(Direction.right)]) |right| {
+                            // u has one right child - the replacement, v, is u's right child
+                            delete_recolor(n, right);
                             self.allocator.destroy(n); // free memory used by u, return v
-                            return left;
+                            return right;
+                        } else {
+                            // no children
+                            std.debug.print("{s}{} ", .{ "\nFound data to delete: ", data });
+                            if (red(n) or n == self.root) {
+                                self.allocator.destroy(n); // free memory used by u, return v
+                                return null; // 0 children - return a sentinel as v
+                            } else {
+                                // If the node being deleted is black and non-root - it will become a double black - defer delete until later
+                                // so we can handle the double black properly
+                                delete_recolor(n, null);
+                                return n;
+                            }
+                            // set delete flag
+                            // in fix_double_black we will delete it there
                         }
-                    } else if (n.children[@intFromEnum(Direction.right)]) |right| {
-                        // u has one right child - the replacement, v, is u's right child
-                        delete_recolor(n, right);
-                        self.allocator.destroy(n); // free memory used by u, return v
-                        return right;
                     } else {
-                        // no children
-                        std.debug.print("{s}{} ", .{ "\nFound data to delete: ", data });
-                        if (red(n)) {
-                            self.allocator.destroy(n); // free memory used by u, return v
-                            return null; // 0 children - return a sentinel as v
-                        } else {
-                            // If the node being deleted is black - it will become a double black - defer delete until later
-                            // so we can handle the double black properly
-                            delete_recolor(n, null);
-                            return n;
-                        }
-                        // set delete flag
-                        // in fix_double_black we will delete it there
+                        n.frequency = n.frequency - 1;
+                        return n;
                     }
                 } else if (data > n.data) { // recurse otherwise if node.data != data
                     n.children[@intFromEnum(Direction.right)] = try do_delete(self, data, n.children[@intFromEnum(Direction.right)]);
@@ -793,6 +816,70 @@ test "delete double-black case 3d" {
     try rbtree.delete(10);
     res = try rbtree.level_order_transversal();
     std.debug.assert(std.mem.eql(u8, "13B1,12B0,14B0,", res));
+}
+
+test "delete root" {
+    var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+    var rbtree = RedBlackTree(u32).new(allocator);
+    try rbtree.insert(1);
+    try rbtree.insert(3);
+    try rbtree.insert(2);
+    try rbtree.delete(2);
+    try rbtree.delete(3);
+    try rbtree.delete(1);
+    const res = try rbtree.level_order_transversal();
+    std.debug.print("{s}{s}", .{ "\n", res });
+    std.debug.assert(std.mem.eql(u8, "", res));
+}
+
+test "deleting non-existent data doesn't cause any errors" {
+    var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+    var rbtree = RedBlackTree(u32).new(allocator);
+    try rbtree.insert(1);
+    try rbtree.insert(3);
+    try rbtree.insert(2);
+    try rbtree.delete(6);
+    try rbtree.delete(3);
+    try rbtree.delete(5);
+    const res = try rbtree.level_order_transversal();
+    std.debug.print("{s}{s}", .{ "\n", res });
+    std.debug.assert(std.mem.eql(u8, "2B1,1R0,", res));
+}
+
+test "inserting and deleting multiple of same value increases frequency" {
+    var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+    var rbtree = RedBlackTree(u32).new(allocator);
+    try rbtree.insert(2);
+    try rbtree.insert(2);
+    const nd = rbtree.get_data(2);
+    std.debug.assert(nd.?.frequency == 2);
+    try rbtree.delete(2);
+    std.debug.assert(nd.?.frequency == 1);
+    try rbtree.delete(2);
+    std.debug.assert(nd.?.frequency == 1);
+    // nd = null;
+    // std.debug.assert(nd == null);
+
+    // TODO: this is dangerous... we may end up freeing node inside rbtree but the outside world does not know
+    // I suppose this is why usually we get the user to create the node, and then pass it in to be linked into
+    // the data structure. So the structure doesn't own the memory but the calling process does
+    // We should redo the code so we DON'T allocate nodes within the red black tree
+    // Delete should return the node deleted -> then the calling process can destroy it
+    // Then the calling process can decide whether to use the heap or the stack as well...
+
+    // var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+    // const allocator = arena.allocator();
+    // const byte = try allocator.create(u8);
+    // byte.* = 128;
+    // std.debug.assert(byte.* == 128);
+    // allocator.destroy(byte);
+    // std.debug.assert(byte.* == 128); // this still passes!! Zig can't detect freed memory ... :(
 }
 
 test "fire away" {


### PR DESCRIPTION
Add logic to free memory when deleting nodes, finish edge cases (adding multiple copies of same value, deleting root node)

TODO: Update data structure to NOT allocate memory internally - we should let the user allocate the nodes themselves and delete them, so they can control how the memory is allocated. Also prevents accidental references to invalid memory (eg. when we delete a node within the tree but the user doesn't know)